### PR TITLE
Change heading line-height to 1

### DIFF
--- a/_sass/_main.scss
+++ b/_sass/_main.scss
@@ -20,7 +20,7 @@ body {
 }
 
 h1, h2, h3, h4, h5, h6 {
-  line-height: 0.5;
+  line-height: 1.0;
 }
 
 /* Main content */


### PR DESCRIPTION
This should stop multiline headings from shrinking into each other